### PR TITLE
Fix QuickTime recording

### DIFF
--- a/SimpleDALPlugin/Stream.swift
+++ b/SimpleDALPlugin/Stream.swift
@@ -143,7 +143,6 @@ class Stream: Object {
             presentationTimeStamp: timestamp,
             decodeTimeStamp: timestamp
         )
-        log(timing)
 
         var error = noErr
 

--- a/SimpleDALPlugin/Stream.swift
+++ b/SimpleDALPlugin/Stream.swift
@@ -15,7 +15,7 @@ class Stream: Object {
     let height = 720
     let frameRate = 30
 
-    private var currentTimeNsec: UInt64 = 0
+    private var currentTimeMsec: UInt64 = 0
     private var sequenceNumber: UInt64 = 0
     private var queueAlteredProc: CMIODeviceStreamQueueAlteredProc?
     private var queueAlteredRefCon: UnsafeMutableRawPointer?
@@ -88,7 +88,7 @@ class Stream: Object {
     ]
 
     func start() {
-        currentTimeNsec = 0
+        currentTimeMsec = 0
         timer.resume()
     }
 
@@ -135,8 +135,8 @@ class Stream: Object {
         }
 
         let duration = 1000 / UInt64(frameRate)
-        currentTimeNsec += duration
-        let timestamp = CMTime(value: CMTimeValue(currentTimeNsec), timescale: CMTimeScale(1000))
+        currentTimeMsec += duration
+        let timestamp = CMTime(value: CMTimeValue(currentTimeMsec), timescale: CMTimeScale(1000))
 
         var timing = CMSampleTimingInfo(
             duration: CMTime(value: CMTimeValue(duration), timescale: CMTimeScale(1000)),

--- a/SimpleDALPlugin/Stream.swift
+++ b/SimpleDALPlugin/Stream.swift
@@ -135,12 +135,7 @@ class Stream: Object {
         }
 
         let duration = 1000 / UInt64(frameRate)
-
-        if currentTimeNsec == 0 {
-            currentTimeNsec = mach_absolute_time() / 1000_000
-        } else {
-            currentTimeNsec += duration
-        }
+        currentTimeNsec += duration
         let timestamp = CMTime(value: CMTimeValue(currentTimeNsec), timescale: CMTimeScale(1000))
 
         var timing = CMSampleTimingInfo(


### PR DESCRIPTION
This fixes QuickTime recording

What I did:
* Make duration consistent (current timestamp - last timestamp == duration)
* Make decodeTimeStamp == presentationTimeStamp
* Use milliseconds instead of nanoseconds
  * nanoseconds and microsecond didn't work (I don't know why)
